### PR TITLE
Change to email as the single point of contact

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,4 +41,4 @@ To take a course from the Data Science minor's upper-level requirements that has
 > Fortunately, there are paths to complete the upper-level minor requirements without taking additional prereqs,
 > such as taking CPSC 368 rather than CPSC 304.
 
-Has your question not been asked or answered here? If so, please ask it [here](https://github.com/UBC-DSCI/ubc-dsci-minor-faq/issues/new?assignees=ttimbers%2C+mgelbart%2C+gcohenfr%2C+cheeren&labels=&template=ubc-data-science-minor-frequently-asked-questions.md&title=UBC+Data+Science+minor+question).
+Has your question not been answered here? If so, please send an email to dsugradadv@stat.ubc.ca.


### PR DESCRIPTION
I think it makes sense to only have one point of contact, so that we are only checking for new questions in one place. Although I generally like having issues or Q&A sites like SO where people can benefits from others questions and answers, there will be questions that are private so we will have to provide and email contact point anyways, so issues is not an option for one points of contact. I think adding more of the commonly asked student email questions to the FAQ can serve the role of issues and be more nicely formatted which makes students more likely to read through it (we can make some upgrades such as adding sections/headings as the FAQ grows). We can use any of the templates from https://github.com/mmistakes/minimal-mistakes or switching to quarto to get a ToC on the page which will make it easier for students if it grows.